### PR TITLE
feat(fits/headers): add functionality for header population for *_cube.fits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "numpy>=1.2,<3.0",
     "matplotlib>3.0,<4.0",
     "pandas>2.0,<=3.0",
-    "astropy>=6.0,<8.0",
+    "astropy>=7.1,<8.0",
     "astroquery>=0.4.8,<=0.4.10",
     "tqdm",
     "natsort",
@@ -113,3 +113,6 @@ indent-style = "space"
 omit = [
     "_version.py",
 ]
+
+[tool.pytest.ini_options]
+addopts = "--log-format='%(asctime)s %(levelname)s %(message)s' --log-date-format='%Y-%m-%d %H:%M:%S'"

--- a/src/spherical/pipeline/fits/headers.py
+++ b/src/spherical/pipeline/fits/headers.py
@@ -1,0 +1,455 @@
+"""
+Module which handles populating fits headers from output files of the SPHERICAL and CHARIS pipeline.
+"""
+
+__author__ = "L. Welzel"
+__all__ = ["update_cube_fits_header_after_reduction"]
+
+import logging
+import warnings
+from copy import deepcopy
+from functools import partial
+from itertools import repeat
+from os import getlogin
+from pathlib import Path
+from socket import getfqdn, gethostname
+from typing import Callable, Literal
+
+import pandas as pd
+from astropy.io.fits.card import VerifyWarning
+from astropy.io.fits.hdu.hdulist import fitsopen
+from astropy.io.fits.header import Header
+
+LOGGER = logging.getLogger(__name__)
+
+
+_OUTPUT_GROUP_PATTERNS = [
+    "coro",
+    "center",
+    "flux",
+]
+
+
+def update_cube_fits_header_after_reduction(
+    path: Path | str,
+    target: Literal["coro", "center", "flux", "all"] = 'all',
+    override_mode_file: Literal["copy", "update"] = "update",
+    override_mode_header: Literal["keep", "update"] = "update",
+) -> None:
+    """
+    Update the FITS header of reduced data cubes.
+
+    Parameters
+    ----------
+    path : Path or str
+        Directory containing the target *_cube.fits and associated files.
+    target : {"coro", "center", "flux", "all"}, default 'all'
+        Which reduction product to update; 'all' processes all targets.
+    override_mode_file : {"copy", "update"}, default 'update'
+        How to handle file overrides.
+    override_mode_header : {"keep", "update"}, default 'update'
+        How to handle header overrides.
+
+    Raises
+    ------
+    AssertionError
+        If path is invalid or target files are missing.
+    NotImplementedError
+        If unsupported modes or multiple HDUs are encountered.
+    """
+    # validate path
+    path = Path(path)
+    assert path.exists(), f"Path {path} does not exist."
+    assert path.is_dir(), f"Path {path} is not a directory."
+
+    # validate target
+    assert target in _OUTPUT_GROUP_PATTERNS + ["all"], f"Target {target} is not valid. Must be one of {_OUTPUT_GROUP_PATTERNS} or 'all'."
+
+    # validate override modes
+    assert override_mode_file in ["copy", "update"], f"Override mode for file {override_mode_file} is not valid. Must be 'copy' or 'update'."
+    assert override_mode_header in ["keep", "update"], f"Override mode for header {override_mode_header} is not valid. Must be 'keep' or 'update'."
+
+    # TODO: implement below
+    if override_mode_file == "copy":
+        raise NotImplementedError(
+            "The 'copy' mode for 'override_mode_file' is not implemented yet. "
+            "Please use 'update' mode instead."
+        )
+    
+    # warn if function might lead to data loss
+    # TODO: unsure if we should warn about this since it would be the default behavior
+    # if override_mode_header == "update" and override_mode_file == "update":
+    #     warnings.warn(
+    #         "The 'update' mode for 'override_mode_header' together with 'update' mode for 'override_mode_file'"
+    #         " is not recommended. This may lead to loss of data in the header.",
+    #         UserWarning
+    #     )
+    
+    # dispatch to the function with specific targets if target is "all"
+    if target == "all":
+        targets = _OUTPUT_GROUP_PATTERNS
+        LOGGER.debug(f"Updating headers for all targets: {targets}.")
+        for resolved_target in targets:
+            LOGGER.debug(f"Updating header for target: {resolved_target}.")
+            try:
+                update_cube_fits_header_after_reduction(
+                    path=path,
+                    target=resolved_target,
+                    override_mode_file=override_mode_file,
+                    override_mode_header=override_mode_header
+                )
+            except Exception as e:
+                LOGGER.error(f"Failed to process header for target {resolved_target}: {e}")
+                pass
+        return
+
+    # validate target
+    target_observation_cube_file_path = path / f"{target}_cube.fits"
+    assert target_observation_cube_file_path.exists(), (
+        f"Target {target} observation cube file {target_observation_cube_file_path} does not exist. "
+        "Please check the path and target."
+    )
+    assert target_observation_cube_file_path.is_file(), (
+        f"Target {target} observation cube file {target_observation_cube_file_path} is not a file. "
+        "Please check the path and target."
+    )
+
+    # get the fits file
+    target_observation_cube_file_path_str = str(target_observation_cube_file_path.resolve().absolute())
+
+    # TODO: unsure if we ever get more than one HDU, but if we do, we should handle it
+    try:
+        with fitsopen(
+            target_observation_cube_file_path_str, 
+            ignore_missing_end=False,
+            memmap=True,
+        ) as hdulist:
+            if len(hdulist) != 1:
+                hdulist.info()
+                raise NotImplementedError("No support for multiple HDUs yet.")
+            memmap: bool = True
+            fits_header: Header = deepcopy(hdulist[0].header)
+            new_header: Header = deepcopy(fits_header)
+
+    except ValueError:
+        # If BZERO/BSCALE/BLANK header keywords present HDU can’t load as memmap
+        with fitsopen(
+            target_observation_cube_file_path_str, 
+            ignore_missing_end=False,
+            memmap=False,
+        ) as hdulist:
+            if len(hdulist) != 1:
+                hdulist.info()
+                raise NotImplementedError("No support for multiple HDUs yet.")
+            memmap: bool = False
+            fits_header: Header = deepcopy(hdulist[0].header)
+            new_header: Header = deepcopy(fits_header)
+
+    try:
+        hdulist.close()
+        del hdulist[0].data  # free memory
+        del hdulist
+    except Exception:
+        LOGGER.warning("Failed to close HDUList or free memory. This is not critical, but may lead to increase memory usage until the gc runs.")
+
+
+    # update the header with spherical metadata
+    new_header = spherical_populate_fits_header(
+        header=new_header, 
+        overwrite=override_mode_header == "update",
+        include_dependency_metadata=True,
+        spherical_key_postfix="POST_PIPE",
+    )
+
+    # collect other data files
+    frame_info_file_path = path / f"frames_info_{target}.csv"
+    frame_info_df = pd.read_csv(frame_info_file_path, index_col=0)
+
+    # get constant columns
+    constant_frame_info_csv_columns = find_constant_columns(
+        frame_info_df, 
+        include_na=False
+    )
+    # expand the keys to be HIERARCH by default
+    constant_frame_info_csv_columns = {
+        f"HIERARCH {key}": value for key, value in constant_frame_info_csv_columns.items()
+    }
+
+    key_path_to_constant_frame_info_csv_file = "HIERARCH SPHERICAL FRAME_INFO_FILE"
+    constant_frame_info_csv_comment = f"constant value from frames_info file ({key_path_to_constant_frame_info_csv_file})"
+    extend_fits_header_with_card(
+        new_header,
+        key=key_path_to_constant_frame_info_csv_file,
+        value=str(frame_info_file_path.resolve().absolute()),
+        comment="Path to the frames_info file for this target observation.",
+        update=override_mode_header == "update",
+    )
+
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', VerifyWarning)
+        new_header.extend(
+            (
+                (k, v, c) for (k, v), c in zip(
+                    constant_frame_info_csv_columns.items(), 
+                    repeat(constant_frame_info_csv_comment)
+                )
+            ),
+            strip=True,
+            update=override_mode_header == "update",
+        )
+
+    # update the fits header
+    with fitsopen(
+        target_observation_cube_file_path_str, 
+        ignore_missing_end=False,
+        memmap=memmap,
+        mode='update',
+        output_verify='fix+warn',
+    ) as hdulist:
+        if len(hdulist) != 1:
+            hdulist.info()
+            raise NotImplementedError("No support for multiple HDUs yet.")
+        hdulist[0].header = new_header
+
+        hdulist.flush(
+            output_verify='fix+warn',
+        )
+
+    return
+
+
+def extend_fits_header_with_card(
+    header: Header, 
+    key: str, 
+    value: str | int | float, 
+    comment: str | None = None,
+    update: bool = True,
+    key_prefix: str = "",
+) -> Header:
+    """
+    Add or update a card in a FITS header.
+
+    Parameters
+    ----------
+    header : Header
+        The FITS header to modify.
+    key : str
+        The keyword to add (HIERARCH prefix applied).
+    value : str, int, or float
+        The value for the keyword.
+    comment : str or None, default None
+        Comment for the card.
+    update : bool, default True
+        Whether to overwrite existing keys.
+    key_prefix : str, default ''
+        Additional prefix for the keyword.
+
+    Returns
+    -------
+    Header
+        The modified FITS header.
+    """
+
+    # validate key
+    key = f"{key_prefix} {key}" if key_prefix else key
+    key = key.upper()
+
+    # handle HIERARCH explictly to supress warnings
+    # if len(key) > 8:
+    #     key = f"HIERARCH {key}"
+
+    # handle HIERARCH explictly to supress warnings, and always add the HIERARCH prefix to the key
+    key = f"HIERARCH {key}"
+
+    # validate value
+    if isinstance(value, str):
+        value = value.strip()
+        # value = ascii(value)  # convert to ASCII string for FITS compatibility
+
+    # TODO: work around for astropy fits header card bug
+    # TODO: tracked in issue: https://github.com/astropy/astropy/issues/17783
+    
+    if comment is None:
+        comment_length = 0
+    else:
+        comment_length = len(comment)
+
+    if (len(key) + len(str(value)) <= 80) and (len(key) + len(str(value)) + comment_length > 80):
+        # key and value fit, but comment does not and will be truncated
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', VerifyWarning)
+            header.extend(
+                [
+                    (key, value, comment),
+                    (f"{key} COMMENT", comment),
+                ],
+                update=update,
+            )
+        return
+
+    header.extend(
+        [(key, value, comment)] if comment else [(key, value)],
+        update=update,
+    )
+    
+    return
+
+
+def spherical_populate_fits_header(
+        header: Header | None, 
+        overwrite: bool = False,
+        include_dependency_metadata: bool = True,
+        spherical_key_postfix: str = ""
+    ) -> Header:
+    """
+    Populate a FITS header with SPHERE pipeline metadata.
+
+    Adds general metadata about the SPHERE reduction software,
+    pipeline step information, and optional dependency versions.
+
+    Parameters
+    ----------
+    header : Header or None
+        Existing header to update, or None to create a new one.
+    overwrite : bool, default False
+        If True, overwrite existing spherical keys.
+    include_dependency_metadata : bool, default True
+        Include versions of Python, charis, esorex, etc.
+    spherical_key_postfix : str, default ''
+        Suffix appended to spherical metadata keys.
+
+    Returns
+    -------
+    Header
+        The updated FITS header.
+    """
+
+    import datetime
+    import subprocess
+    from importlib.metadata import version
+
+    if header is None:
+        header = Header()
+
+    key_prefix = f"SPHERICAL {spherical_key_postfix}" if spherical_key_postfix else "SPHERICAL"
+
+    now = datetime.datetime.now(datetime.timezone.utc).astimezone()
+
+    # bind 'header', 'update' and 'key_prefix="SPHERICAL *"' into a helper 'ac'
+    ac_general: Callable[..., Header] = partial(
+        extend_fits_header_with_card,
+        header,
+        update=True,       # does not really matter since we except this part to not change
+        key_prefix="SPHERICAL",
+    )
+
+    ac: Callable[..., Header] = partial(
+        extend_fits_header_with_card,
+        header,
+        update=not overwrite, # flip bool (overwrite == not update)
+        key_prefix=key_prefix,
+    )
+
+    # SPHERICAL METADATA GENERAL
+    ac_general('DESC', 'VLT/SPHERE Observation Database and IFS Data Analysis Pipeline')
+    ac_general('AUTHOR NAME', 'M. Samland', 'author of the package')
+    ac_general('AUTHOR EMAIL', 'NA')
+
+    ac_general('PUB NAME', 'Astronomy & Astrophysics, Volume 668, id.A84, 16 pp.')
+    ac_general('PUB TITLE', 'Spectral cube extraction for the VLT/SPHERE IFS. Open-source pipeline with full forward modeling and improved sensitivity.')
+    ac_general('PUB AUTHORS', 'M. Samland, T. D. Brandt, J. Milli, P. Delorme, and A. Vigan')
+    ac_general('PUB YEAR', '2022')
+    ac_general('PUB DOI', 'https://doi.org/10.1051/0004-6361/202244587')
+    ac_general('PUB ADS', 'https://ui.adsabs.harvard.edu/abs/2022A%26A...668A..84S/abstract')
+    
+    # SPHERICAL METADATA PIPELINE STEP SPECIFIC
+    ac('VERSION', version("spherical"), 'version of the reducer software')
+    ac('GIT URL', subprocess.getoutput("git config --get remote.origin.url").strip(), 'url of the git repository')
+    ac('GIT HASH', subprocess.getoutput("git rev-parse --short HEAD").strip(), 'git hash')
+    ac('GIT BRANCH', subprocess.getoutput("git rev-parse --abbrev-ref HEAD").strip(), 'active git branch')
+
+    # FITS WRITING METADATA
+    ac('FITS AUTHOR', getlogin(), 'author of the FITS file')
+    ac('FITS HOSTNAME', gethostname(), 'hostname of the machine where the FITS file was written')
+    ac('FITS FQDN', getfqdn(), 'fully qualified domain name of the machine where the FITS file was written')
+    ac('FITS WRITE DATE', now.strftime("%Y-%m-%d"), 'date of the FITS file writing')
+    ac('FITS WRITE TIME',  now.strftime("%H:%M:%S"), 'time of the FITS file writing')
+
+
+    # DEPENDENCIES
+    if include_dependency_metadata:
+        import re
+
+        # PYTHON METADATA
+        ac('PYTHON VERSION', subprocess.getoutput("python --version").strip())
+
+        # PIPELINE DEPENDENCIES METADATA
+        ac('CHARIS VERSION', version("charis"))
+
+        def resolve_esorex_meta(esorex_meta: str) -> dict[str: str]:
+            # Extract the version using regex
+            version_match = re.search(r"ESO Recipe Execution Tool, version ([\d\.]+)", esorex_meta)
+            version = version_match.group(1) if version_match else "UNKNOWN"
+
+            # Extract the libraries line
+            libraries_match = re.search(r"Libraries used: (.+)", esorex_meta)
+            libraries_line = libraries_match.group(1) if libraries_match else "UNKNOWN"
+
+            # Split and parse the libraries into a dictionary
+            libraries = {}
+            for lib in libraries_line.split(', '):
+                lib_parts = lib.split(' = ')
+                if len(lib_parts) == 2:
+                    name, ver = lib_parts
+                    name = name.strip()
+                    ver = ver.strip()
+                    libraries[name] = ver
+
+            esorex_meta_dict = {
+                "VERSION": version,
+                **{
+                    f"LIB {name.upper()}": ver for name, ver in libraries.items()
+                }
+            }
+
+            return esorex_meta_dict
+            
+        esorex_meta = subprocess.getoutput("esorex --version").strip()
+        esorex_meta = resolve_esorex_meta(esorex_meta)
+        for key, value in esorex_meta.items():
+            ac(f'ESOREX {key}', value)
+
+        
+
+    return header
+
+
+def find_constant_columns(df: pd.DataFrame, include_na: bool = False) -> dict:
+    """
+    Identify columns in a DataFrame with constant values.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame to inspect.
+    include_na : bool, default False
+        If True, treat NaN as a valid constant.
+
+    Returns
+    -------
+    dict
+        Mapping of column names to their constant value.
+    """
+
+    df = df[sorted(df.columns)]
+
+    constants = {}
+    for col in df.columns:
+        # count unique values, optionally including NaN
+        nuniq = df[col].nunique(dropna=not include_na)
+        if nuniq == 1:
+            # grab that one value (iloc[0] works even if it's NaN)
+            constants[col] = df[col].iloc[0]
+    return constants
+

--- a/src/spherical/pipeline/fits/tests/test_ifs_pipeline_fits_header.py
+++ b/src/spherical/pipeline/fits/tests/test_ifs_pipeline_fits_header.py
@@ -1,0 +1,210 @@
+import logging
+import os
+from pathlib import Path
+from typing import Literal
+
+import pytest
+from astropy.io.fits.header import Header
+
+from spherical.pipeline.fits import headers
+
+LOGGER = logging.getLogger(__name__)
+IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
+
+
+def _get_spherical_test_data_directory() -> Path:
+    """
+    Locate the package's 'tests/data' folder or skip dependent tests if not present.
+
+    Returns
+    -------
+    Path
+        Root path to 'spherical/tests/data'.
+
+    Raises
+    ------
+    pytest.skip
+        If the directory does not exist or is not a folder.
+    """
+    import spherical
+    spherical_repo_root = Path(spherical.__file__).resolve().parents[2]
+    test_data_dir = spherical_repo_root / "tests/data"
+
+    try:
+        assert test_data_dir.exists(), "Test data directory does not exist. Cannot run tests that require test data."
+        assert test_data_dir.is_dir(), "Test data path is not a directory. Cannot run tests that require test data."
+    except AssertionError as e:
+        pytest.skip(f"Skipping test because {e}.")
+
+    return test_data_dir
+
+
+class TestUnitExtendFitsHeaderWithCard:
+    """
+    Unit tests for the 'extend_fits_header_with_card' function.
+    """
+
+    @pytest.mark.filterwarnings("ignore::astropy.io.fits.verify.VerifyWarning")
+    @pytest.mark.usefixtures("tmp_path_factory")
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "TEST",
+            "TEST KEY"
+            "TEST_KEY",
+            "__TEST__",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "value",
+        [
+            0,
+            0.0,
+            1.0e5,
+            "test_value",
+            "test value",
+            "test value with spaces",
+            "test_value_with_underscores",
+            "test-value-with-dashes",
+            "test:value:with:colons",
+            "test/value/with/slashes",
+            "test\\value\\with\\backslashes",
+            "test.value.with.dots",
+            "test,value,with,commas",
+            "test@value@with@at-signs",
+            "test_special!@#$%^&*()_+-=[]{}|;':\",.<>?/~`",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "comment",
+        [
+            "This is a test comment.",
+            "Another test comment.",
+            "Comment with special characters: !@#$%^&*()",
+            "Comment with spaces and punctuation.",
+        ],
+    )
+    def test_extend_fits_header_with_card_basic(self, tmp_path_factory, key: str, value: str | int | float, comment: str):
+        """
+        Test the basic functionality of 'extend_fits_header_with_card'.
+        """
+
+        tmp_dir = tmp_path_factory.mktemp(f"{Path(__file__).stem}")
+        tmp_file_path = tmp_dir / "test_extend_fits_header_with_card_basic.fits"
+
+        hdr = Header()
+
+        headers.extend_fits_header_with_card(
+            hdr, 
+            key=key, 
+            value=value, 
+            comment=comment, 
+            update=True
+        )
+
+        assert hdr[f'HIERARCH {key}'] == value
+        assert hdr.comments[f'HIERARCH {key}'] == comment
+
+        with open(tmp_file_path, 'wb') as f:
+            hdr.tofile(f)
+
+
+class TestIntegrationUpdateFitsHeaderAfterReduction:
+    """
+    Integration tests for updating FITS headers after IFS reduction.
+    """
+
+    # TODO: this should copy the test data to a temporary directory and work on that copy in a function scope fixture
+    @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Do not run test in GitHub CI.")
+    @pytest.mark.filterwarnings("ignore::astropy.io.fits.verify.VerifyWarning")
+    @pytest.mark.parametrize(
+        ("target_observation_name"),
+        [
+            # TODO: segregate between GitHub CI and local tests
+            # pytest.param(
+            #     "PATH_TO_TEST_DATA", 
+            #     marks=pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Do not run test in GitHub.")
+            # ),
+            "PATH_TO_TEST_DATA", 
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("target"),
+        ["coro", "center", "flux", "all"],
+    )
+    @pytest.mark.parametrize(
+        ("override_mode_file"),
+        [
+            "update",
+            pytest.param(
+                "copy", 
+                marks=pytest.mark.xfail(reason="'copy' mode not implemented yet")
+            ),
+        ],
+    )
+    def test_make_fits_header_from_ifs_reduction(
+        self,
+        caplog, 
+        target_observation_name: str, 
+        target: Literal["coro", "center", "flux", "all"], 
+        override_mode_file: Literal["copy", "update"],
+        override_mode_header: Literal["keep", "update"] = "update",
+        multiple_match: Literal["run_all", "skip", "fail"] = "fail",
+    ):
+        """
+        Test 'update_cube_fits_header_after_reduction' on real pipeline outputs.
+
+        Parametrize over observation names, targets, and override modes,
+        handling GitHub CI skips, expected failures, and multiple-directory logic.
+
+        Parameters
+        ----------
+        caplog
+            Pytest fixture for capturing logs.
+        target_observation_name : str
+            Name of the test reduction directory to locate.
+        target : {"coro","center","flux","all"}
+            Which FITS cube variant to update.
+        override_mode_file : {"copy","update"}
+            Whether to copy or update the file (copy is xfail).
+        override_mode_header : {"keep","update"}
+            Whether to preserve or overwrite existing headers.
+        multiple_match : {"run_all","skip","fail"}, default "fail"
+            How to handle finding multiple matching test dirs.
+        """
+
+        if target_observation_name == "PATH_TO_TEST_DATA":
+            pytest.fail(
+                reason="TODO: Please set 'target_observation_name' to a valid test observation name or path to test data. RE: issue https://github.com/m-samland/spherical/issues/61"
+            )
+
+        # get root directory of test observation(s)
+        spherical_test_data_dir = _get_spherical_test_data_directory()
+        reduction_dir = list(spherical_test_data_dir.rglob(target_observation_name))
+
+        if len(reduction_dir) == 0:
+            pytest.skip(f"Skipping test because no reduction directory found for {target_observation_name}.")
+        elif len(reduction_dir) > 1 and (multiple_match == "fail"):
+            pytest.fail(f"Expected exactly one reduction directory for {target_observation_name}, found {len(reduction_dir)}. Failing test because multiple directories found and 'multiple_match' is set to 'fail'. Set 'multiple_match' to 'run_all' or 'skip' to allow multiple directories.")
+        elif len(reduction_dir) > 1 and (multiple_match == "skip"):
+            pytest.skip(f"Skipping test because multiple reduction directories found for {target_observation_name}. Set 'multiple_match' to 'run_all' or 'fail' to run the test with multiple directories.")
+        elif len(reduction_dir) > 1 and (multiple_match == "run_all"):
+            LOGGER.warning(f"Multiple reduction directories found for {target_observation_name}. Running test with all directories. Set 'multiple_match' to 'fail' or 'skip' to change this behavior.")
+            for dir in reduction_dir:
+                LOGGER.debug(f"Running test with directory: {dir}")
+                self.test_make_fits_header_from_ifs_reduction(caplog, dir.stem, multiple_match=multiple_match)
+            return
+        elif len(reduction_dir) == 1:
+            reduction_dir = reduction_dir[0]
+        else:
+            pytest.fail(f"Unexpected number of reduction directories found for {target_observation_name}. Expected 1, found {len(reduction_dir)}.")
+
+        LOGGER.debug(f"Resolved test reduction directory: {reduction_dir}")
+
+        # run the function to test
+        headers.update_cube_fits_header_after_reduction(
+            path=reduction_dir,
+            target=target,
+            override_mode_file=override_mode_file,
+            override_mode_header=override_mode_header,
+        )


### PR DESCRIPTION
# Add FITS header updater for SPHERICAL/CHARIS outputs
### Summary
This PR introduces update_cube_fits_header_after_reduction, a utility that walks through SPHERICAL/CHARIS pipeline outputs (coro, center, flux, or all) and injects pipeline metadata into each cube’s FITS header.

In support of this new feature:
#### fits/headers
- Added integration tests for update_cube_fits_header_after_reduction; these tests exercise the utility against real pipeline outputs and are skipped on GitHub Actions to avoid heavy CI dependencies (see issue [#61](https://github.com/m-samland/spherical/issues/61)).
- Added extend_fits_header_with_card, with unit tests covering a expected key/value/comment cases.

#### pyproject.toml
- Bumped to astropy>=7.1 to leverage recent fixes for long FITS header cards (see astropy PR [#17782](https://github.com/astropy/astropy/pull/17782) and issue [#17783](https://github.com/astropy/astropy/issues/17783)).

### 📌 Type of change

Please delete options that are not relevant (and this line).
- Bug fix (ensures FITS header handling for long cards)
- New feature (non-breaking change which adds functionality)

### 🚨 Motivation and Context

The SPHERICAL pipeline produces multiple cube variants (coro, center, flux), but until now there’s no automated way to propagate pipeline (and partial observation) info their FITS headers with provenance and dependency metadata. 
This PR:
- Centralizes header updates in update_cube_fits_header_after_reduction.
- Ensures end-users and archives can (partially) trace pipeline versions, git info, author, host, and dependency versions directly in the FITS metadata.
- Adds tests to guard against regressions and to validate both unit-level and real-data behavior (locally).

### ✅ Checklist

- [ x] I’ve tested the changes locally.
- [ ] I’ve updated documentation as necessary. Functions all have sufficient DOC strings.
- [ x] My changes follow the project's coding style and conventions.
- [ x] All tests pass successfully. Some xfail. (skipped on CI)

### 🔍 How to test/review

Step 0: Check in the SPHERICAL section of the header if there is info that should not be propagated (e.g. email, NA at the moment). See 'spherical_populate_fits_header' function.

Unit tests can run out-of-the-box but integration tests rely on pipeline outputs which we do not have a consistent way to test with (#61 ):
Step 1: point the TestIntegrationUpdateFitsHeaderAfterReduction.test_make_fits_header_from_ifs_reduction (and _get_spherical_test_data_directory) to an SPHERICAL IFS output directory with coro, center, and flux cubes. (pytest will warn you if you don't and mark the 4 integration tests as failed)
Step 2: run tests $pytest -k 'fits_header'
Step 3: manually inspect the headers :(  -> they have basic SPHERICAL and frame info. [I did not want to spend a lot of time on making this automated without knowing which test data we will use.]

### 📸 Screenshots

![image](https://github.com/user-attachments/assets/73986052-4eea-4bc4-8b48-009fc233802a)

### 🔖 Related Issues/Tickets
List any related issues, tickets, or tasks here:
- Relates to #64 #61 
- Addresses astropy long header-card bug: astropy/astropy#17783

### TODO:
- The functionality is stand-alone at the moment, and needs to be ran after the pipeline finishes, but should be integrated into the SPHERICAL pipeline (after cube building). Waiting for the pipeline steps to factored out (https://github.com/m-samland/spherical/issues/61#issuecomment-2888480420).
- Add more rich context to the header, taking inspiration from SPHERE-DC header data. 
- Check if CHARIS can already propagate some header cards?