### PR TITLE
IFS pipeline: resume-by-default with a single `force` control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,14 @@ This project follows [Semantic Versioning](https://semver.org/) and the [Keep a 
   precomputed mask and `_mask_not_usable_observations()` are removed (behaviour
   unchanged). Summary column sets moved to a module-level `SUMMARY_COLUMNS`
   used by `view()`.
+- **IFS pipeline now resumes by default** – Enabled steps whose outputs already exist on disk are skipped, so re-running over a growing target list is cheap and adding new targets "just works". Recomputation is opt-in via the new single `PipelineStepsConfig.force` field (`True`, or a set of step names that cascades to all downstream steps). `reduction_status` now treats a resume-skip (`skipped_complete`) as healthy/complete. `check_output()` is derived from a new step registry (also fixes the `additional_outputs` path it checked) ([@m-samland](https://github.com/m-samland)) (#TBD).
 
 ### Removed
 - **Dropped unused notebook dependencies `ipympl` and `ipydatagrid`** – Neither was imported by the package or any example notebook (`show_in_browser()` uses astropy's `jsviewer`, not `ipydatagrid`). The `notebook` group is now `ipython`, `jupyterlab`, `ipywidgets`, `seaborn`; `ipywidgets` is kept because `tqdm.auto` uses it for widget progress bars in JupyterLab ([@m-samland](https://github.com/m-samland)).
 - **Removed custom `utils.progress` module** – Replaced the custom tqdm environment-detection wrapper with `tqdm.auto`, which provides more robust notebook vs. console detection, proper `ipywidgets` fallback, and async support out of the box ([@m-samland](https://github.com/m-samland)) ([#104](https://github.com/m-samland/spherical/issues/104)).
 - Deprecated `FAILED_SEQ` / `_ready_flag` readiness path (superseded by
   `HCI_READY`).
+- **`PipelineStepsConfig.overwrite_calibration`/`overwrite_bundle`/`overwrite_preprocessing`/`overwrite_trap`** – Superseded by the new `force` field ([@m-samland](https://github.com/m-samland)) (#TBD).
 
 ### Fixed
 - `ROTATION` now stores `np.nan` (not the `-10000` sentinel) when derotation is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,14 +41,14 @@ This project follows [Semantic Versioning](https://semver.org/) and the [Keep a 
   precomputed mask and `_mask_not_usable_observations()` are removed (behaviour
   unchanged). Summary column sets moved to a module-level `SUMMARY_COLUMNS`
   used by `view()`.
-- **IFS pipeline now resumes by default** – Enabled steps whose outputs already exist on disk are skipped, so re-running over a growing target list is cheap and adding new targets "just works". Recomputation is opt-in via the new single `PipelineStepsConfig.force` field (`True`, or a set of step names that cascades to all downstream steps). `reduction_status` now treats a resume-skip (`skipped_complete`) as healthy/complete. `check_output()` is derived from a new step registry (also fixes the `additional_outputs` path it checked) ([@m-samland](https://github.com/m-samland)) (#TBD).
+- **IFS pipeline now resumes by default** – Enabled steps whose outputs already exist on disk are skipped, so re-running over a growing target list is cheap and adding new targets "just works". Recomputation is opt-in via the new single `PipelineStepsConfig.force` field (`True`, or a set of step names that cascades to all downstream steps). `reduction_status` now treats a resume-skip (`skipped_complete`) as healthy/complete. `check_output()` is derived from a new step registry (also fixes the `additional_outputs` path it checked) ([@m-samland](https://github.com/m-samland)) ([#121](https://github.com/m-samland/spherical/pull/121)).
 
 ### Removed
 - **Dropped unused notebook dependencies `ipympl` and `ipydatagrid`** – Neither was imported by the package or any example notebook (`show_in_browser()` uses astropy's `jsviewer`, not `ipydatagrid`). The `notebook` group is now `ipython`, `jupyterlab`, `ipywidgets`, `seaborn`; `ipywidgets` is kept because `tqdm.auto` uses it for widget progress bars in JupyterLab ([@m-samland](https://github.com/m-samland)).
 - **Removed custom `utils.progress` module** – Replaced the custom tqdm environment-detection wrapper with `tqdm.auto`, which provides more robust notebook vs. console detection, proper `ipywidgets` fallback, and async support out of the box ([@m-samland](https://github.com/m-samland)) ([#104](https://github.com/m-samland/spherical/issues/104)).
 - Deprecated `FAILED_SEQ` / `_ready_flag` readiness path (superseded by
   `HCI_READY`).
-- **`PipelineStepsConfig.overwrite_calibration`/`overwrite_bundle`/`overwrite_preprocessing`/`overwrite_trap`** – Superseded by the new `force` field ([@m-samland](https://github.com/m-samland)) (#TBD).
+- **`PipelineStepsConfig.overwrite_calibration`/`overwrite_bundle`/`overwrite_preprocessing`/`overwrite_trap`** – Superseded by the new `force` field ([@m-samland](https://github.com/m-samland)) ([#121](https://github.com/m-samland/spherical/pull/121)).
 
 ### Fixed
 - `ROTATION` now stores `np.nan` (not the `-10000` sentinel) when derotation is

--- a/examples/ifs_reduction_template.py
+++ b/examples/ifs_reduction_template.py
@@ -47,6 +47,13 @@ config.steps = config.steps.merge(
     run_trap_detection=True,
 )
 
+# ===== RESUME / FORCE =====
+# By default the pipeline RESUMES: any enabled step whose outputs already exist
+# on disk is skipped, so re-running over a growing target list is cheap and
+# adding new targets "just works". To force recomputation:
+#   config.steps = config.steps.merge(force=True)                 # redo everything enabled
+#   config.steps = config.steps.merge(force={"extract_cubes"})    # redo extract_cubes AND all downstream steps (cascade)
+
 # ===== CONFIGURE ESO DATA DOWNLOAD SETTINGS OF PROPRIETARY DATA =====
 config.preprocessing = config.preprocessing.merge(
     eso_username=None,  # Set to your ESO username if needed

--- a/src/spherical/pipeline/ifs_reduction.py
+++ b/src/spherical/pipeline/ifs_reduction.py
@@ -625,16 +625,11 @@ def check_output(reduction_directory, observation_object_list: list[Union[IFSObs
 
     Notes
     -----
-    Required files checked include:
-    - wavelengths.fits: Wavelength calibration solution (nm units)
-    - coro_cube.fits: Coronagraphic science data cube
-    - center_cube.fits: Unsaturated PSF reference data cube  
-    - frames_info_*.csv: Frame metadata and quality flags
-    - image_centers_fitted_robust.fits: Astrometric solution
-    - psf_cube_for_postprocessing.fits: Combined calibrated flux PSF frames
-    - spot_amplitude_variation.fits: Temporal variation of normalized spot amplitudes
-    - additional_outputs/flux_stamps_calibrated_bg_corrected.fits: Photometric reference data
-    - additional_outputs/spot_amplitudes.fits: Satellite spot photometry
+    Completeness is determined by the per-step expected outputs declared in
+    ``spherical.pipeline.step_registry.STEP_REGISTRY``. The function checks
+    all expected outputs from each registered pipeline step, excluding steps
+    marked as ``internal_guard`` or ``is_trap``. The registry is the source
+    of truth for which files are required.
 
     Missing files may indicate:
     - Incomplete pipeline execution

--- a/src/spherical/pipeline/ifs_reduction.py
+++ b/src/spherical/pipeline/ifs_reduction.py
@@ -99,6 +99,7 @@ matplotlib.use(backend='Agg')  # Must be set before any matplotlib imports
 
 # Local imports
 from spherical.pipeline.pipeline_config import IFSReductionConfig, defaultIFSReduction
+from spherical.pipeline.step_registry import StepDirs, _forced, should_run, validate_force
 from spherical.pipeline.steps.bundle_output import run_bundle_output
 from spherical.pipeline.steps.cube_header_update import run_cube_header_update
 from spherical.pipeline.steps.download_data import download_data_for_observation, update_observation_file_paths
@@ -310,7 +311,8 @@ def execute_target(
     
     # Extract step configuration for cleaner code
     steps = config.steps
-    
+    validate_force(steps.force)
+
     # Get directory paths from config
     raw_directory = config.directories.raw_directory
     reduction_directory = config.directories.reduction_directory
@@ -395,7 +397,13 @@ def execute_target(
 
         calibration_time_name = str(observation.frames['WAVECAL']['DP.ID'][0][6:])  # type: ignore
         wavecal_outputdir = os.path.join(str(reduction_directory), 'IFS/calibration', obs_band, calibration_time_name)
-        
+
+        dirs = StepDirs(
+            converted_dir=Path(converted_dir),
+            cube_outputdir=Path(cube_outputdir),
+            wavecal_outputdir=Path(wavecal_outputdir),
+        )
+
         if not os.path.exists(outputdir):
             os.makedirs(outputdir)
 
@@ -406,11 +414,11 @@ def execute_target(
                 instrument=instrument,
                 calibration_parameters=calibration_parameters,
                 wavecal_outputdir=wavecal_outputdir,
-                overwrite_calibration=steps.overwrite_calibration,
+                overwrite_calibration=_forced("reduce_calibration", steps.force),
                 logger=logger,
             )
 
-        if steps.extract_cubes:
+        if should_run("extract_cubes", steps.extract_cubes, dirs, steps.force, logger):
             extract_cubes_with_multiprocessing(
                 observation=observation,
                 frame_types_to_extract=['CORO', 'CENTER', 'FLUX'],
@@ -420,10 +428,9 @@ def execute_target(
                 cube_outputdir=cube_outputdir,
                 logger=logger,
                 non_least_square_methods=non_least_square_methods,
-                extract_cubes=steps.extract_cubes,
             )
 
-        if steps.bundle_output:
+        if should_run("bundle_output", steps.bundle_output, dirs, steps.force, logger):
             run_bundle_output(
                 frame_types_to_extract=frame_types_to_extract,
                 cube_outputdir=cube_outputdir,
@@ -431,16 +438,15 @@ def execute_target(
                 extraction_parameters=extraction_parameters,
                 instrument=instrument,
                 non_least_square_methods=non_least_square_methods,
-                overwrite_bundle=steps.overwrite_bundle,
                 bundle_hexagons=steps.bundle_hexagons,
                 bundle_residuals=steps.bundle_residuals,
                 logger=logger,
             )
 
-        if steps.compute_frames_info:
+        if should_run("compute_frames_info", steps.compute_frames_info, dirs, steps.force, logger):
             run_frame_info_computation(observation, converted_dir, logger=logger)
 
-        if steps.cube_header_update:
+        if should_run("cube_header_update", steps.cube_header_update, dirs, steps.force, logger):
             run_cube_header_update(
                 frame_types_to_extract=frame_types_to_extract,
                 converted_dir=converted_dir,
@@ -449,34 +455,32 @@ def execute_target(
                 logger=logger,
             )
 
-        if steps.find_centers:
+        if should_run("find_centers", steps.find_centers, dirs, steps.force, logger):
             fit_centers_in_parallel(
                 converted_dir=converted_dir,
                 observation=observation,
-                overwrite=steps.overwrite_preprocessing,
                 ncpu=reduction_parameters['ncpu_find_center'],
                 logger=logger,
                 )
 
-        if steps.process_extracted_centers:
+        if should_run("process_extracted_centers", steps.process_extracted_centers, dirs, steps.force, logger):
             run_polynomial_center_fit(
                 converted_dir=converted_dir,
                 extraction_parameters=extraction_parameters,
                 non_least_square_methods=non_least_square_methods,
-                overwrite_preprocessing=steps.overwrite_preprocessing,
                 logger=logger,
             )
 
-        if steps.plot_image_center_evolution:
+        if should_run("plot_image_center_evolution", steps.plot_image_center_evolution, dirs, steps.force, logger):
             run_image_center_evolution_plot(converted_dir, logger=logger)
 
-        if steps.calibrate_spot_photometry:
-            run_spot_photometry_calibration(converted_dir, steps.overwrite_preprocessing, logger=logger)
+        if should_run("calibrate_spot_photometry", steps.calibrate_spot_photometry, dirs, steps.force, logger):
+            run_spot_photometry_calibration(converted_dir, logger=logger)
 
-        if steps.calibrate_flux_psf:
-            run_flux_psf_calibration(converted_dir, steps.overwrite_preprocessing, reduction_parameters, logger=logger)
-            
-        if steps.spot_to_flux:
+        if should_run("calibrate_flux_psf", steps.calibrate_flux_psf, dirs, steps.force, logger):
+            run_flux_psf_calibration(converted_dir, reduction_parameters, logger=logger)
+
+        if should_run("spot_to_flux", steps.spot_to_flux, dirs, steps.force, logger):
             run_spot_to_flux_normalization(converted_dir, reduction_parameters, logger=logger)
         
         end = time.time()

--- a/src/spherical/pipeline/ifs_reduction.py
+++ b/src/spherical/pipeline/ifs_reduction.py
@@ -99,7 +99,7 @@ matplotlib.use(backend='Agg')  # Must be set before any matplotlib imports
 
 # Local imports
 from spherical.pipeline.pipeline_config import IFSReductionConfig, defaultIFSReduction
-from spherical.pipeline.step_registry import StepDirs, _forced, should_run, validate_force
+from spherical.pipeline.step_registry import STEP_REGISTRY, StepDirs, _forced, expected_outputs, should_run, validate_force
 from spherical.pipeline.steps.bundle_output import run_bundle_output
 from spherical.pipeline.steps.cube_header_update import run_cube_header_update
 from spherical.pipeline.steps.download_data import download_data_for_observation, update_observation_file_paths
@@ -664,42 +664,19 @@ def check_output(reduction_directory, observation_object_list: list[Union[IFSObs
     missing_files_reduction = []
 
     for observation in observation_object_list:
-        outputdir = output_directory_path(
-            reduction_directory, 
-            observation,
-            method)
-        additional_outputs_dir = Path(outputdir).parent / 'additional_outputs'
-        
-        # Files that should be in converted_dir
-        files_to_check_main = [
-            'wavelengths.fits',
-            'coro_cube.fits',
-            'center_cube.fits',
-            'frames_info_flux.csv',
-            'frames_info_center.csv',
-            'frames_info_coro.csv',
-            'image_centers_fitted_robust.fits',
-            'psf_cube_for_postprocessing.fits',
-            'spot_amplitude_variation.fits',
-        ]
-        
-        # Files that should be in additional_outputs
-        files_to_check_additional = [
-            'flux_stamps_calibrated_bg_corrected.fits',
-            'spot_amplitudes.fits',
-        ]
-
-        missing_files = []
-        for file in files_to_check_main:
-            if not path.isfile(path.join(outputdir, file)):
-                missing_files.append(file)
-        for file in files_to_check_additional:
-            if not path.isfile(additional_outputs_dir / file):
-                missing_files.append(f"additional_outputs/{file}")
-        if len(missing_files) > 0:
-            reduced.append(False)
-        else:
-            reduced.append(True)
+        converted_dir = Path(output_directory_path(reduction_directory, observation, method))
+        dirs = StepDirs(
+            converted_dir=converted_dir,
+            cube_outputdir=converted_dir.parent,
+        )
+        missing_files: list[str] = []
+        for step, spec in STEP_REGISTRY.items():
+            if spec.internal_guard or spec.is_trap:
+                continue  # internal-guard/idempotent or TRAP (separate dir tree)
+            for p in expected_outputs(step, dirs):
+                if not p.exists():
+                    missing_files.append(str(p.relative_to(converted_dir.parent)))
+        reduced.append(len(missing_files) == 0)
         missing_files_reduction.append(missing_files)
-    
+
     return reduced, missing_files_reduction

--- a/src/spherical/pipeline/pipeline_config.py
+++ b/src/spherical/pipeline/pipeline_config.py
@@ -188,7 +188,12 @@ class PipelineStepsConfig:
     run_trap_reduction: bool = True
     run_trap_detection: bool = True
     
-    # Overwrite settings
+    # Resume/force control. False = resume (skip enabled steps whose outputs
+    # exist); True = redo all enabled steps; a set of step names forces those
+    # steps AND every step after them (cascade). Replaces the overwrite_* flags.
+    force: bool | set[str] = False
+
+    # Overwrite settings (deprecated — removed once step callers stop reading them)
     overwrite_calibration: bool = True
     overwrite_bundle: bool = True
     overwrite_preprocessing: bool = True

--- a/src/spherical/pipeline/pipeline_config.py
+++ b/src/spherical/pipeline/pipeline_config.py
@@ -193,12 +193,6 @@ class PipelineStepsConfig:
     # steps AND every step after them (cascade). Replaces the overwrite_* flags.
     force: bool | set[str] = False
 
-    # Overwrite settings (deprecated — removed once step callers stop reading them)
-    overwrite_calibration: bool = True
-    overwrite_bundle: bool = True
-    overwrite_preprocessing: bool = True
-    overwrite_trap: bool = True
-    
     # Class-level list of all IFS pipeline steps (excludes TRAP and overwrite settings)
     _IFS_STEPS = [
         'download_data',

--- a/src/spherical/pipeline/run_trap.py
+++ b/src/spherical/pipeline/run_trap.py
@@ -40,6 +40,7 @@ from spherical.pipeline.logging_utils import (
     remove_queue_listener,
 )
 from spherical.pipeline.pipeline_config import IFSReductionConfig
+from spherical.pipeline.step_registry import StepDirs, _forced, should_run, validate_force, write_marker
 from spherical.pipeline.toolbox import make_target_folder_string
 
 # The default IFS coronagraph transmission this module injects relies on trap's
@@ -334,6 +335,10 @@ def run_trap_on_observation(
     # Create TRAP result folder
     os.makedirs(result_folder, exist_ok=True)
 
+    force = reduction_config.steps.force
+    validate_force(force)
+    trap_dirs = StepDirs(trap_result_folder=Path(result_folder))
+
     # Initialize logging for TRAP session with trap_ prefix for log files
     context = get_pipeline_log_context(observation)
     logger = get_pipeline_logger(
@@ -438,7 +443,7 @@ def run_trap_on_observation(
                     bad_frames=bad_frames,
                     amplitude_modulation_full=amplitude_modulation_full,
                     xy_image_centers=xy_image_centers,
-                    overwrite=trap_config.processing.overwrite_reduction,
+                    overwrite=_forced("run_trap_reduction", force),
                     verbose=trap_config.processing.verbose,
                     use_progress_bar=trap_config.processing.use_progress_bar,
                 )
@@ -463,7 +468,7 @@ def run_trap_on_observation(
                 # Re-raise the original exception
                 raise
 
-        if reduction_config.steps.run_trap_detection:
+        if should_run("run_trap_detection", reduction_config.steps.run_trap_detection, trap_dirs, force, logger):
             logger.info("Starting TRAP detection", extra={"step": "trap_detection", "status": "started"})
             
             # Fix B: Enhanced diagnostic logging for TRAP parameters
@@ -563,6 +568,7 @@ def run_trap_on_observation(
             )
             
             logger.info("TRAP detection completed", extra={"step": "trap_detection", "status": "success"})
+            write_marker("run_trap_detection", result_folder)
 
         # Session completion logging
         end_time = time.time()

--- a/src/spherical/pipeline/step_registry.py
+++ b/src/spherical/pipeline/step_registry.py
@@ -131,3 +131,20 @@ def _forced(step: str, force: "bool | set[str]") -> bool:
         return False
     first = min(STEP_ORDER.index(s) for s in force)
     return STEP_ORDER.index(step) >= first
+
+
+def should_run(step: str, enabled: bool, dirs: StepDirs, force: "bool | set[str]", logger) -> bool:
+    """Decide whether to run *step*: skip (resume) when its outputs already
+    exist, unless forced. Not used for ``internal_guard`` steps."""
+    if not enabled:
+        return False
+    if _forced(step, force):
+        return True
+    outs = expected_outputs(step, dirs)
+    if outs and all(p.exists() for p in outs):
+        logger.info(
+            f"{step}: outputs present — skipping",
+            extra={"step": STEP_REGISTRY[step].log_name, "status": "skipped_complete"},
+        )
+        return False
+    return True

--- a/src/spherical/pipeline/step_registry.py
+++ b/src/spherical/pipeline/step_registry.py
@@ -1,0 +1,133 @@
+"""Single source of truth for pipeline step identity, products, and ordering.
+
+Update THIS module (and nowhere else) when a step's output filenames or its
+logged ``extra={"step": ...}`` name change: ``should_run``, ``check_output``,
+and the ``reduction_status`` aggregator all rely on the names declared here.
+
+Intentionally imports only the standard library so it stays usable without the
+pipeline extra (no charis/trap/scipy).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class StepDirs:
+    """Runtime directories a step reads/writes. Only the fields a given step
+    needs are populated; the rest keep harmless defaults."""
+
+    converted_dir: Path = Path()
+    cube_outputdir: Path = Path()
+    wavecal_outputdir: Path = Path()
+    trap_result_folder: Path | None = None
+
+    @property
+    def additional_outputs(self) -> Path:
+        # The step modules write this inside converted_dir (see find_star.py etc.).
+        return self.converted_dir / "additional_outputs"
+
+
+@dataclass(frozen=True)
+class StepSpec:
+    """Describes one pipeline step.
+
+    Args:
+        log_name: The ``extra={"step": ...}`` string the step emits in structured
+            logs (may differ from the config-attribute key).
+        outputs: Files whose presence means the step is complete, given StepDirs.
+        is_final: Marks the terminal step whose completion means the IFS target
+            is done.
+        internal_guard: True when the step decides skip itself (calibration,
+            TRAP reduction) or is inherently idempotent (download); such steps are
+            not gated by ``should_run`` and declare no ``outputs``.
+    """
+
+    log_name: str
+    outputs: Callable[[StepDirs], list[Path]]
+    is_final: bool = False
+    internal_guard: bool = False
+    is_trap: bool = False  # TRAP step: excluded from IFS-reduction check_output()
+
+
+def marker_for(step: str, directory: Path | str) -> Path:
+    """Path of a step's zero-byte completion marker inside *directory*."""
+    return Path(directory) / f".{step}.done"
+
+
+def write_marker(step: str, directory: Path | str) -> None:
+    """Write a step's completion marker (parent-side, after the step succeeds)."""
+    marker = marker_for(step, directory)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.touch()
+
+
+def _marker_output(step: str, dirs: StepDirs) -> list[Path]:
+    directory = {
+        "extract_cubes": dirs.cube_outputdir,
+        "run_trap_detection": dirs.trap_result_folder,
+    }[step]
+    return [marker_for(step, directory)]
+
+
+def _converted(*names: str) -> Callable[[StepDirs], list[Path]]:
+    return lambda d: [d.converted_dir / n for n in names]
+
+
+def _additional(*names: str) -> Callable[[StepDirs], list[Path]]:
+    return lambda d: [d.additional_outputs / n for n in names]
+
+
+_NONE: Callable[[StepDirs], list[Path]] = lambda d: []  # noqa: E731
+
+# Insertion order == canonical pipeline order in ifs_reduction.py, TRAP last.
+STEP_REGISTRY: dict[str, StepSpec] = {
+    "download_data": StepSpec("download_data", _NONE, internal_guard=True),
+    "reduce_calibration": StepSpec("wavelength_calibration", _NONE, internal_guard=True),
+    "extract_cubes": StepSpec("extract_cubes", lambda d: _marker_output("extract_cubes", d)),
+    "bundle_output": StepSpec("bundle_output", _converted("coro_cube.fits", "center_cube.fits", "wavelengths.fits")),
+    "compute_frames_info": StepSpec(
+        "frame_info_computation",
+        _converted("frames_info_coro.csv", "frames_info_center.csv", "frames_info_flux.csv"),
+    ),
+    "cube_header_update": StepSpec("cube_header_update", _NONE),
+    "find_centers": StepSpec("fit_centers", _converted("image_centers.fits")),
+    "plot_image_center_evolution": StepSpec("plot_center_evolution", _NONE),
+    "process_extracted_centers": StepSpec("polynomial_center_fit", _converted("image_centers_fitted_robust.fits")),
+    "calibrate_spot_photometry": StepSpec("spot_photometry_calibration", _additional("spot_amplitudes.fits")),
+    "calibrate_flux_psf": StepSpec("flux_psf_calibration", _converted("psf_cube_for_postprocessing.fits")),
+    "spot_to_flux": StepSpec("spot_to_flux_normalization", _converted("spot_amplitude_variation.fits"), is_final=True),
+    "run_trap_reduction": StepSpec("trap_reduction", _NONE, internal_guard=True, is_trap=True),
+    "run_trap_detection": StepSpec("trap_detection", lambda d: _marker_output("run_trap_detection", d), is_trap=True),
+}
+
+STEP_ORDER: list[str] = list(STEP_REGISTRY)
+
+
+def expected_outputs(step: str, dirs: StepDirs) -> list[Path]:
+    """Files whose presence means *step* is complete for this target."""
+    return STEP_REGISTRY[step].outputs(dirs)
+
+
+def validate_force(force: "bool | set[str]") -> None:
+    """Raise ValueError if *force* is a set naming an unknown step."""
+    if isinstance(force, set):
+        unknown = force - set(STEP_REGISTRY)
+        if unknown:
+            raise ValueError(
+                f"Unknown step name(s) in force: {sorted(unknown)}. "
+                f"Valid names: {sorted(STEP_REGISTRY)}"
+            )
+
+
+def _forced(step: str, force: "bool | set[str]") -> bool:
+    """True if *step* must recompute: force=True, or *step* is at/after the
+    earliest force-named step in STEP_ORDER (cascade)."""
+    if force is True:
+        return True
+    if not force:  # False or empty set
+        return False
+    first = min(STEP_ORDER.index(s) for s in force)
+    return STEP_ORDER.index(step) >= first

--- a/src/spherical/pipeline/steps/bundle_output.py
+++ b/src/spherical/pipeline/steps/bundle_output.py
@@ -143,7 +143,6 @@ def run_bundle_output(
     extraction_parameters,
     instrument,
     non_least_square_methods,
-    overwrite_bundle,
     bundle_hexagons,
     bundle_residuals,
     logger,
@@ -215,8 +214,6 @@ def run_bundle_output(
             Wavelength midpoints for non-linear sampling
     non_least_square_methods : list of str
         List of extraction methods that are not least-squares.
-    overwrite_bundle : bool
-        Whether to overwrite existing bundle outputs.
     bundle_hexagons : bool
         Whether to bundle hexagon outputs.
     bundle_residuals : bool
@@ -250,7 +247,6 @@ def run_bundle_output(
     ...     },
     ...     instrument=charis.instruments.SPHERE('YJ'),
     ...     non_least_square_methods=["optext", "apphot3", "apphot5"],
-    ...     overwrite_bundle=True,
     ...     bundle_hexagons=True,
     ...     bundle_residuals=True
     ... )
@@ -260,7 +256,6 @@ def run_bundle_output(
     logger.debug(f"Parameters: frame_types={frame_types_to_extract}, "
                  f"method={extraction_parameters['method']}, "
                  f"linear_wavelength={extraction_parameters['linear_wavelength']}, "
-                 f"overwrite_bundle={overwrite_bundle}, "
                  f"bundle_hexagons={bundle_hexagons}, bundle_residuals={bundle_residuals}")
 
     for key in frame_types_to_extract:
@@ -269,16 +264,16 @@ def run_bundle_output(
             if bundle_hexagons:
                 bundle_IFS_output_into_cubes(
                     key, cube_outputdir, logger=logger, output_type='hexagons',
-                    overwrite=overwrite_bundle, converted_dir=converted_dir)
+                    overwrite=True, converted_dir=converted_dir)
 
             if bundle_residuals:
                 bundle_IFS_output_into_cubes(
                     key, cube_outputdir, logger=logger, output_type='residuals',
-                    overwrite=overwrite_bundle, converted_dir=converted_dir)
+                    overwrite=True, converted_dir=converted_dir)
 
             bundle_IFS_output_into_cubes(
                 key, cube_outputdir, logger=logger, output_type='resampled',
-                overwrite=overwrite_bundle, converted_dir=converted_dir)
+                overwrite=True, converted_dir=converted_dir)
 
         except Exception:
             logger.exception(f"Failed to bundle cubes for frame type: {key}", extra={"step": f"bundle_output_{key.lower()}", "status": "failed"})
@@ -298,7 +293,7 @@ def run_bundle_output(
             logger.debug("Using instrument-provided wavelength midpoints.")
 
         output_path = os.path.join(converted_dir, 'wavelengths.fits')
-        fits.writeto(output_path, wavelengths.astype('float32'), overwrite=overwrite_bundle)
+        fits.writeto(output_path, wavelengths.astype('float32'), overwrite=True)
         logger.info(f"Wavelength solution written to: {output_path}")
 
     except Exception:

--- a/src/spherical/pipeline/steps/extract_cubes.py
+++ b/src/spherical/pipeline/steps/extract_cubes.py
@@ -301,6 +301,12 @@ def extract_cubes_with_multiprocessing(
 
     logger.info("Step finished", extra={"step": "extract_cubes", "status": "success"})
 
+    # Parent-side completion marker: the workers write per-DIT cubes directly and
+    # partial failures are tolerated, so file presence alone cannot prove the step
+    # finished. This marker is the resume signal (see step_registry).
+    from spherical.pipeline.step_registry import write_marker
+    write_marker("extract_cubes", cube_outputdir)
+
 
 def _parallel_extraction_worker(
     task: Tuple[str, int, str | None, str, str, Dict[str, Any]],

--- a/src/spherical/pipeline/steps/find_star.py
+++ b/src/spherical/pipeline/steps/find_star.py
@@ -550,7 +550,7 @@ def _fit_center_for_cube(args) -> Tuple[int, np.ndarray, np.ndarray, np.ndarray,
     return index, (spot_centers, spot_distances, image_centers, spot_amplitudes)
 
 @optional_logger
-def fit_centers_in_parallel(converted_dir: str, observation, logger, overwrite: bool = True, ncpu: int = 4):
+def fit_centers_in_parallel(converted_dir: str, observation, logger, ncpu: int = 4):
     """Find and fit star centers in SPHERE/IFS coronagraphic data using waffle spots.
 
     This is the sixth step in the SPHERE/IFS data reduction pipeline. It locates
@@ -591,8 +591,6 @@ def fit_centers_in_parallel(converted_dir: str, observation, logger, overwrite: 
             Instrument configuration for pixel scale and other parameters
         - frames: dict
             Frame metadata for determining observation mode
-    overwrite : bool, optional
-        Whether to overwrite existing center files. Default is True.
     ncpu : int, optional
         Number of CPU cores to use for parallel processing. Default is 4.
 
@@ -616,7 +614,6 @@ def fit_centers_in_parallel(converted_dir: str, observation, logger, overwrite: 
     >>> fit_centers_in_parallel(
     ...     converted_dir="/path/to/converted",
     ...     observation=obs,
-    ...     overwrite=True,
     ...     ncpu=8
     ... )
     """
@@ -667,10 +664,10 @@ def fit_centers_in_parallel(converted_dir: str, observation, logger, overwrite: 
     additional_outputs_dir.mkdir(exist_ok=True)
     
     # Write outputs - image_centers.fits stays in converted_dir, others move to additional_outputs
-    fits.writeto(additional_outputs_dir / 'spot_centers.fits', spot_centers, overwrite=overwrite)
-    fits.writeto(additional_outputs_dir / 'spot_distances.fits', spot_distances, overwrite=overwrite)
-    fits.writeto(additional_outputs_dir / 'spot_fit_amplitudes.fits', spot_fit_amplitudes, overwrite=overwrite)
-    fits.writeto(os.path.join(converted_dir, 'image_centers.fits'), image_centers, overwrite=overwrite)
+    fits.writeto(additional_outputs_dir / 'spot_centers.fits', spot_centers, overwrite=True)
+    fits.writeto(additional_outputs_dir / 'spot_distances.fits', spot_distances, overwrite=True)
+    fits.writeto(additional_outputs_dir / 'spot_fit_amplitudes.fits', spot_fit_amplitudes, overwrite=True)
+    fits.writeto(os.path.join(converted_dir, 'image_centers.fits'), image_centers, overwrite=True)
     logger.info("Finished fit_centers_in_parallel", extra={"step": "fit_centers", "status": "success"})
 
 @optional_logger

--- a/src/spherical/pipeline/steps/flux_psf_calibration.py
+++ b/src/spherical/pipeline/steps/flux_psf_calibration.py
@@ -5,8 +5,6 @@ Parameters
 ----------
 converted_dir : str
     Directory where the output files are stored and written.
-overwrite_preprocessing : bool
-    Whether to overwrite existing files.
 reduction_parameters : dict
     Reduction parameters dict, must contain 'flux_combination_method', 'exclude_first_flux_frame', and 'exclude_first_flux_frame_all'.
 """
@@ -28,7 +26,6 @@ from spherical.pipeline.steps.find_star import guess_position_psf, star_centers_
 @optional_logger
 def run_flux_psf_calibration(
     converted_dir: str,
-    overwrite_preprocessing: bool,
     reduction_parameters: Dict[str, str | bool],
     logger,
 ) -> None:
@@ -90,8 +87,6 @@ def run_flux_psf_calibration(
     ----------
     converted_dir : str
         Directory containing the input files and where outputs will be written.
-    overwrite_preprocessing : bool
-        Whether to overwrite existing output files.
     reduction_parameters : dict
         Reduction parameters dict, must contain:
         - flux_combination_method: str
@@ -161,7 +156,6 @@ def run_flux_psf_calibration(
     --------
     >>> run_flux_psf_calibration(
     ...     converted_dir="/path/to/converted",
-    ...     overwrite_preprocessing=True,
     ...     reduction_parameters={
     ...         "flux_combination_method": "mean",
     ...         "exclude_first_flux_frame": True,
@@ -263,20 +257,20 @@ def run_flux_psf_calibration(
     flux_centers = np.expand_dims(np.swapaxes(np.array(flux_centers), 0, 1), axis=2)
     flux_amplitudes = np.swapaxes(np.array(flux_amplitudes), 0, 1)
     logger.debug(f"Extracted flux_centers shape: {flux_centers.shape}, flux_amplitudes shape: {flux_amplitudes.shape}")
-    fits.writeto(additional_outputs_dir / 'flux_centers.fits', flux_centers, overwrite=overwrite_preprocessing)
-    fits.writeto(additional_outputs_dir / 'flux_gauss_amplitudes.fits', flux_amplitudes, overwrite=overwrite_preprocessing)
+    fits.writeto(additional_outputs_dir / 'flux_centers.fits', flux_centers, overwrite=True)
+    fits.writeto(additional_outputs_dir / 'flux_gauss_amplitudes.fits', flux_amplitudes, overwrite=True)
     flux_stamps = toolbox.extract_satellite_spot_stamps(
         flux_cube, flux_centers, stamp_size=57, shift_order=3, plot=False)
     logger.debug(f"Extracted flux_stamps shape: {flux_stamps.shape}")
     fits.writeto(additional_outputs_dir / 'flux_stamps_uncalibrated.fits',
-                 flux_stamps.astype('float32'), overwrite=overwrite_preprocessing)
+                 flux_stamps.astype('float32'), overwrite=True)
     if len(frames_info['FLUX']['INS4 FILT2 NAME'].unique()) > 1:
         logger.warning('Non-unique ND filters in sequence.', extra={"step": "flux_psf_calibration", "status": "failed"})
         raise ValueError('Non-unique ND filters in sequence.')
     else:
         ND = frames_info['FLUX']['INS4 FILT2 NAME'].unique()[0]
     _, attenuation = transmission.transmission_nd(ND, wave=wavelengths)
-    fits.writeto(additional_outputs_dir / 'nd_attenuation.fits', attenuation, overwrite=overwrite_preprocessing)
+    fits.writeto(additional_outputs_dir / 'nd_attenuation.fits', attenuation, overwrite=True)
     dits_flux = np.array(frames_info['FLUX']['DET SEQ1 DIT'])
     dits_center = np.array(frames_info['CENTER']['DET SEQ1 DIT'])
     unique_dits_center, unique_dits_center_counts = np.unique(dits_center, return_counts=True)
@@ -288,11 +282,11 @@ def run_flux_psf_calibration(
         dits_factor = most_common_dit_center / dits_flux
     dit_factor_center = most_common_dit_center / dits_center
     fits.writeto(additional_outputs_dir / 'center_frame_dit_adjustment_factors.fits',
-                 dit_factor_center, overwrite=overwrite_preprocessing)
+                 dit_factor_center, overwrite=True)
     flux_stamps_calibrated = flux_stamps * dits_factor[None, :, None, None]
     flux_stamps_calibrated = flux_stamps_calibrated / attenuation[:, np.newaxis, np.newaxis, np.newaxis]
     fits.writeto(additional_outputs_dir / 'flux_stamps_dit_nd_calibrated.fits',
-                 flux_stamps_calibrated, overwrite=overwrite_preprocessing)
+                 flux_stamps_calibrated, overwrite=True)
     flux_photometry = flux_calibration.get_aperture_photometry(
         flux_stamps_calibrated, aperture_radius_range=[1, 15],
         bg_aperture_inner_radius=15, bg_aperture_outer_radius=18)
@@ -300,9 +294,9 @@ def run_flux_psf_calibration(
     pickle.dump(flux_photometry, filehandler)
     filehandler.close()
     fits.writeto(os.path.join(converted_dir, 'flux_amplitude_calibrated.fits'),
-                 flux_photometry['psf_flux_bg_corr_all'], overwrite=overwrite_preprocessing)
+                 flux_photometry['psf_flux_bg_corr_all'], overwrite=True)
     fits.writeto(additional_outputs_dir / 'flux_snr.fits',
-                 flux_photometry['snr_all'], overwrite=overwrite_preprocessing)
+                 flux_photometry['snr_all'], overwrite=True)
     
     plt.close()
     plt.plot(flux_photometry['aperture_sizes'], flux_photometry['snr_all'][:, :, 0])
@@ -312,7 +306,7 @@ def run_flux_psf_calibration(
     plt.close()
     bg_sub_flux_stamps_calibrated = flux_stamps_calibrated - flux_photometry['psf_bg_counts_all'][:, :, None, None]
     fits.writeto(additional_outputs_dir / 'flux_stamps_calibrated_bg_corrected.fits',
-                 bg_sub_flux_stamps_calibrated.astype('float32'), overwrite=overwrite_preprocessing)
+                 bg_sub_flux_stamps_calibrated.astype('float32'), overwrite=True)
     flux_calibration_indices, indices_of_discontinuity = flux_calibration.get_flux_calibration_indices(
         frames_info['CENTER'], frames_info['FLUX'])
     flux_calibration_indices.to_csv(os.path.join(converted_dir, 'flux_calibration_indices.csv'))
@@ -353,5 +347,5 @@ def run_flux_psf_calibration(
     flux_calibration_frames = np.array(flux_calibration_frames)
     flux_calibration_frames = np.swapaxes(flux_calibration_frames, 0, 1)
     fits.writeto(os.path.join(converted_dir, 'psf_cube_for_postprocessing.fits'),
-                 flux_calibration_frames.astype('float32'), overwrite=overwrite_preprocessing)
+                 flux_calibration_frames.astype('float32'), overwrite=True)
     logger.info("Step finished", extra={"step": "flux_psf_calibration", "status": "success"})

--- a/src/spherical/pipeline/steps/process_centers.py
+++ b/src/spherical/pipeline/steps/process_centers.py
@@ -9,8 +9,6 @@ extraction_parameters : dict
     Extraction parameters dict, must contain 'method' and 'linear_wavelength'.
 non_least_square_methods : list
     List of method names that are not least-square based.
-overwrite_preprocessing : bool
-    Whether to overwrite existing files.
 """
 
 import os
@@ -28,7 +26,6 @@ def run_polynomial_center_fit(
     converted_dir: str,
     extraction_parameters: Dict[str, str | bool],
     non_least_square_methods: List[str],
-    overwrite_preprocessing: bool,
     logger
 ) -> None:
     """
@@ -69,8 +66,6 @@ def run_polynomial_center_fit(
             Whether linear wavelength sampling was used
     non_least_square_methods : list
         List of method names that are not least-square based.
-    overwrite_preprocessing : bool
-        Whether to overwrite existing output files.
     logger : logging.Logger
         Logger instance injected by @optional_logger for structured logging.
 
@@ -103,7 +98,6 @@ def run_polynomial_center_fit(
     ...         "linear_wavelength": True
     ...     },
     ...     non_least_square_methods=["optext", "apphot3", "apphot5"],
-    ...     overwrite_preprocessing=True,
     ...     logger=logger
     ... )
     """
@@ -171,6 +165,6 @@ def run_polynomial_center_fit(
                 logger.exception(f"Frame {frame_idx}: Polyfit failed (robust)", extra={"step": "polynomial_center_fit", "status": "failed"})
                 image_centers_fitted2[:, frame_idx, 0] = np.nan
                 image_centers_fitted2[:, frame_idx, 1] = np.nan
-    fits.writeto(os.path.join(converted_dir, 'image_centers_fitted.fits'), image_centers_fitted, overwrite=overwrite_preprocessing)
-    fits.writeto(os.path.join(converted_dir, 'image_centers_fitted_robust.fits'), image_centers_fitted2, overwrite=overwrite_preprocessing)
+    fits.writeto(os.path.join(converted_dir, 'image_centers_fitted.fits'), image_centers_fitted, overwrite=True)
+    fits.writeto(os.path.join(converted_dir, 'image_centers_fitted_robust.fits'), image_centers_fitted2, overwrite=True)
     logger.info("Step finished", extra={"step": "polynomial_center_fit", "status": "success"})

--- a/src/spherical/pipeline/steps/spot_photometry.py
+++ b/src/spherical/pipeline/steps/spot_photometry.py
@@ -5,8 +5,6 @@ Parameters
 ----------
 converted_dir : str
     Directory where the output files are stored and written.
-overwrite_preprocessing : bool
-    Whether to overwrite existing files.
 """
 import os
 from pathlib import Path
@@ -21,7 +19,7 @@ from spherical.pipeline.logging_utils import optional_logger
 
 
 @optional_logger
-def run_spot_photometry_calibration(converted_dir: str, overwrite_preprocessing: bool, logger) -> None:
+def run_spot_photometry_calibration(converted_dir: str, logger) -> None:
     """
     Calibrate photometry of satellite spots in SPHERE/IFS data.
 
@@ -58,8 +56,6 @@ def run_spot_photometry_calibration(converted_dir: str, overwrite_preprocessing:
     ----------
     converted_dir : str
         Directory containing the input files and where outputs will be written.
-    overwrite_preprocessing : bool
-        Whether to overwrite existing output files.
     logger : logging.Logger
         Logger instance injected by @optional_logger for structured logging.
 
@@ -90,7 +86,6 @@ def run_spot_photometry_calibration(converted_dir: str, overwrite_preprocessing:
     --------
     >>> run_spot_photometry_calibration(
     ...     converted_dir="/path/to/converted",
-    ...     overwrite_preprocessing=True,
     ...     logger=logger
     ... )
     """
@@ -112,8 +107,8 @@ def run_spot_photometry_calibration(converted_dir: str, overwrite_preprocessing:
     satellite_psf_stamps = toolbox.extract_satellite_spot_stamps(center_cube, spot_centers, stamp_size=57, shift_order=3, plot=False)
     logger.debug(f"Extracted satellite_psf_stamps shape: {satellite_psf_stamps.shape}")
     master_satellite_psf_stamps = np.nanmean(np.nanmean(satellite_psf_stamps, axis=2), axis=1)
-    fits.writeto(additional_outputs_dir / 'satellite_psf_stamps.fits', satellite_psf_stamps.astype('float32'), overwrite=overwrite_preprocessing)
-    fits.writeto(additional_outputs_dir / 'master_satellite_psf_stamps.fits', master_satellite_psf_stamps.astype('float32'), overwrite=overwrite_preprocessing)
+    fits.writeto(additional_outputs_dir / 'satellite_psf_stamps.fits', satellite_psf_stamps.astype('float32'), overwrite=True)
+    fits.writeto(additional_outputs_dir / 'master_satellite_psf_stamps.fits', master_satellite_psf_stamps.astype('float32'), overwrite=True)
     stamp_size = [satellite_psf_stamps.shape[-1], satellite_psf_stamps.shape[-2]]
     stamp_center = [satellite_psf_stamps.shape[-1] // 2, satellite_psf_stamps.shape[-2] // 2]
     bg_aperture = CircularAnnulus(stamp_center, r_in=15, r_out=18)
@@ -135,7 +130,7 @@ def run_spot_photometry_calibration(converted_dir: str, overwrite_preprocessing:
     bg_corr_satellite_psf_stamps = satellite_psf_stamps - bg_counts[:, :, :, None, None]
     fits.writeto(
         additional_outputs_dir / 'satellite_psf_stamps_bg_corrected.fits',
-        bg_corr_satellite_psf_stamps.astype('float32'), overwrite=overwrite_preprocessing)
+        bg_corr_satellite_psf_stamps.astype('float32'), overwrite=True)
     aperture = CircularAperture(stamp_center, 3)
     psf_mask = aperture.to_mask(method='center')
     psf_mask = psf_mask.to_image(stamp_size) > 0
@@ -145,11 +140,11 @@ def run_spot_photometry_calibration(converted_dir: str, overwrite_preprocessing:
         np.nansum(bg_corr_satellite_psf_stamps, axis=2), axis=1)
     fits.writeto(
         additional_outputs_dir / 'spot_amplitudes.fits',
-        flux_sum, overwrite=overwrite_preprocessing)
+        flux_sum, overwrite=True)
     fits.writeto(
         additional_outputs_dir / 'spot_snr.fits',
-        spot_snr, overwrite=overwrite_preprocessing)
+        spot_snr, overwrite=True)
     fits.writeto(
         additional_outputs_dir / 'master_satellite_psf_stamps_bg_corrected.fits',
-        master_satellite_psf_stamps_bg_corr.astype('float32'), overwrite=overwrite_preprocessing)
+        master_satellite_psf_stamps_bg_corr.astype('float32'), overwrite=True)
     logger.info("Step finished", extra={"step": "spot_photometry_calibration", "status": "success"})

--- a/src/spherical/scripts/aggregate_reduction_status.py
+++ b/src/spherical/scripts/aggregate_reduction_status.py
@@ -118,9 +118,11 @@ def aggregate(root: Path) -> list[dict]:
                 current["last_status"] = r["status"]
 
                 # Check completion based on pipeline type
+                # A resume-skip of the final step is as healthy as a fresh success:
+                # its outputs exist from a prior completed run.
                 if (
                     r["step"] == final_step
-                    and r["status"].lower() == "success"
+                    and r["status"].lower() in ("success", "skipped_complete")
                 ):
                     current["complete"] = True
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -274,13 +274,14 @@ class TestPipelineStepsConfig:
         merged = config.merge(
             download_data=False,
             run_trap_detection=False,
-            overwrite_calibration=False
+            force={"extract_cubes"}
         )
-        
+
         assert config.download_data is True  # Original unchanged
         assert merged.download_data is False  # Merged changed
         assert merged.run_trap_detection is False
-        assert merged.overwrite_calibration is False
+        assert config.force is False  # Original unchanged
+        assert merged.force == {"extract_cubes"}
 
 
 class TestIFSReductionConfig:

--- a/tests/test_reduction_status_resume.py
+++ b/tests/test_reduction_status_resume.py
@@ -1,0 +1,43 @@
+"""reduction_status must treat a resume-skip as healthy/complete."""
+import json
+
+from spherical.scripts.aggregate_reduction_status import aggregate
+
+
+def _write_log(path, records):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+
+
+def _rec(step, status):
+    return {"target": "HD1", "band": "OBS_H", "night": "2020-01-01", "step": step, "status": status}
+
+
+def test_skipped_complete_final_step_is_complete(tmp_path):
+    _write_log(
+        tmp_path / "a" / "reduction.jsonlog",
+        [_rec("extract_cubes", "skipped_complete"), _rec("spot_to_flux_normalization", "skipped_complete")],
+    )
+    rows = aggregate(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["complete"] is True
+
+
+def test_failed_final_step_is_incomplete(tmp_path):
+    _write_log(
+        tmp_path / "b" / "reduction.jsonlog",
+        [_rec("spot_to_flux_normalization", "failed")],
+    )
+    rows = aggregate(tmp_path)
+    assert rows[0]["complete"] is False
+
+
+def test_plain_skipped_final_step_is_incomplete(tmp_path):
+    _write_log(
+        tmp_path / "c" / "reduction.jsonlog",
+        [_rec("spot_to_flux_normalization", "skipped")],
+    )
+    rows = aggregate(tmp_path)
+    assert rows[0]["complete"] is False

--- a/tests/test_resume_skip.py
+++ b/tests/test_resume_skip.py
@@ -119,3 +119,25 @@ def test_overwrite_fields_removed():
     cfg = PipelineStepsConfig()
     for gone in ("overwrite_calibration", "overwrite_bundle", "overwrite_preprocessing", "overwrite_trap"):
         assert not hasattr(cfg, gone), gone
+
+
+def test_check_output_uses_registry_and_real_additional_dir(tmp_path, monkeypatch):
+    from spherical.pipeline import ifs_reduction as ir
+
+    # Point output_directory_path at a converted dir we control.
+    converted = tmp_path / "IFS/observation/T/OBS_H/2020-01-01/optext/converted"
+    converted.mkdir(parents=True)
+    monkeypatch.setattr(ir, "output_directory_path", lambda rd, obs, method='optext': str(converted) + "/")
+
+    # Create every registry output for a "complete" target.
+    dirs = sr.StepDirs(converted_dir=converted, cube_outputdir=converted.parent, wavecal_outputdir=tmp_path)
+    for step, spec in sr.STEP_REGISTRY.items():
+        if spec.internal_guard or spec.is_trap:
+            continue
+        for p in sr.expected_outputs(step, dirs):
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.touch()
+
+    reduced, missing = ir.check_output(str(tmp_path), [object()])
+    assert reduced == [True]
+    assert missing == [[]]

--- a/tests/test_resume_skip.py
+++ b/tests/test_resume_skip.py
@@ -104,3 +104,12 @@ def test_should_run_runs_when_output_missing(tmp_path):
 def test_should_run_side_effect_step_always_runs(tmp_path):
     log = MagicMock()
     assert sr.should_run("cube_header_update", True, _dirs(tmp_path), False, log) is True
+
+
+def test_config_force_defaults_false():
+    assert PipelineStepsConfig().force is False
+
+
+def test_config_force_merge_set():
+    cfg = PipelineStepsConfig().merge(force={"extract_cubes"})
+    assert cfg.force == {"extract_cubes"}

--- a/tests/test_resume_skip.py
+++ b/tests/test_resume_skip.py
@@ -1,0 +1,70 @@
+"""Unit tests for the resume/skip step registry and force logic."""
+from pathlib import Path
+
+import pytest
+
+from spherical.pipeline import step_registry as sr
+from spherical.pipeline.pipeline_config import PipelineStepsConfig
+
+
+def _dirs(tmp_path: Path) -> sr.StepDirs:
+    return sr.StepDirs(
+        converted_dir=tmp_path / "converted",
+        cube_outputdir=tmp_path / "cubes",
+        wavecal_outputdir=tmp_path / "wavecal",
+        trap_result_folder=tmp_path / "trap",
+    )
+
+
+def test_step_order_covers_config_steps_and_trap_last():
+    # Every registry key is a real PipelineStepsConfig boolean.
+    cfg = PipelineStepsConfig()
+    for step in sr.STEP_REGISTRY:
+        assert hasattr(cfg, step), step
+    # TRAP steps are the final two, in reduction->detection order.
+    assert sr.STEP_ORDER[-2:] == ["run_trap_reduction", "run_trap_detection"]
+    # Exactly one final step.
+    finals = [s for s, spec in sr.STEP_REGISTRY.items() if spec.is_final]
+    assert finals == ["spot_to_flux"]
+
+
+def test_expected_outputs_locations(tmp_path):
+    d = _dirs(tmp_path)
+    assert sr.expected_outputs("bundle_output", d) == [
+        d.converted_dir / "coro_cube.fits",
+        d.converted_dir / "center_cube.fits",
+        d.converted_dir / "wavelengths.fits",
+    ]
+    # additional_outputs lives INSIDE converted_dir (matches the step modules).
+    assert sr.expected_outputs("calibrate_spot_photometry", d) == [
+        d.converted_dir / "additional_outputs" / "spot_amplitudes.fits",
+    ]
+    # Side-effect steps declare no outputs.
+    assert sr.expected_outputs("cube_header_update", d) == []
+
+
+def test_marker_roundtrip(tmp_path):
+    d = _dirs(tmp_path)
+    marker = sr.expected_outputs("extract_cubes", d)[0]
+    assert not marker.exists()
+    sr.write_marker("extract_cubes", d.cube_outputdir)
+    assert marker.exists()
+
+
+def test_forced_cascade():
+    force = {"extract_cubes"}
+    assert sr._forced("extract_cubes", force) is True
+    assert sr._forced("run_trap_reduction", force) is True   # downstream
+    assert sr._forced("reduce_calibration", force) is False  # upstream
+    assert sr._forced("download_data", force) is False       # upstream
+    assert sr._forced("spot_to_flux", True) is True
+    assert sr._forced("spot_to_flux", False) is False
+    assert sr._forced("spot_to_flux", set()) is False
+
+
+def test_validate_force_rejects_unknown():
+    with pytest.raises(ValueError):
+        sr.validate_force({"extract_cube"})  # typo
+    sr.validate_force({"extract_cubes"})  # ok, no raise
+    sr.validate_force(True)
+    sr.validate_force(False)

--- a/tests/test_resume_skip.py
+++ b/tests/test_resume_skip.py
@@ -1,5 +1,6 @@
 """Unit tests for the resume/skip step registry and force logic."""
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -68,3 +69,38 @@ def test_validate_force_rejects_unknown():
     sr.validate_force({"extract_cubes"})  # ok, no raise
     sr.validate_force(True)
     sr.validate_force(False)
+
+
+def test_should_run_disabled_even_when_forced(tmp_path):
+    log = MagicMock()
+    assert sr.should_run("extract_cubes", False, _dirs(tmp_path), True, log) is False
+
+
+def test_should_run_forced_ignores_existing(tmp_path):
+    d = _dirs(tmp_path)
+    sr.write_marker("extract_cubes", d.cube_outputdir)  # outputs exist
+    log = MagicMock()
+    assert sr.should_run("extract_cubes", True, d, True, log) is True
+
+
+def test_should_run_skips_when_complete_and_logs(tmp_path):
+    d = _dirs(tmp_path)
+    d.converted_dir.mkdir(parents=True)
+    (d.converted_dir / "image_centers.fits").touch()  # find_centers output
+    log = MagicMock()
+    assert sr.should_run("find_centers", True, d, False, log) is False
+    # Skip is logged with the canonical log_name and the new status.
+    _, kwargs = log.info.call_args
+    assert kwargs["extra"] == {"step": "fit_centers", "status": "skipped_complete"}
+
+
+def test_should_run_runs_when_output_missing(tmp_path):
+    d = _dirs(tmp_path)
+    d.converted_dir.mkdir(parents=True)
+    log = MagicMock()
+    assert sr.should_run("find_centers", True, d, False, log) is True
+
+
+def test_should_run_side_effect_step_always_runs(tmp_path):
+    log = MagicMock()
+    assert sr.should_run("cube_header_update", True, _dirs(tmp_path), False, log) is True

--- a/tests/test_resume_skip.py
+++ b/tests/test_resume_skip.py
@@ -113,3 +113,9 @@ def test_config_force_defaults_false():
 def test_config_force_merge_set():
     cfg = PipelineStepsConfig().merge(force={"extract_cubes"})
     assert cfg.force == {"extract_cubes"}
+
+
+def test_overwrite_fields_removed():
+    cfg = PipelineStepsConfig()
+    for gone in ("overwrite_calibration", "overwrite_bundle", "overwrite_preprocessing", "overwrite_trap"):
+        assert not hasattr(cfg, gone), gone


### PR DESCRIPTION
## Summary

Makes the IFS reduction pipeline **resume by default** and replaces the tangled `overwrite_*` flags with a single, coherent `force` control.

Previously, whether an already-reduced target got re-processed on a re-run was a patchwork: four `overwrite_*` flags (all defaulting to `True`) whose meaning differed by step — some were real skip guards, others were only passed to `fits.writeto(overwrite=...)` (so setting them `False` crashed with `OSError` instead of skipping). There was **no per-target/per-step "already done → skip" gate** at all, so adding new targets to a list re-extracted cubes and re-ran all preprocessing + both TRAP phases for the targets that were already finished.

Now: re-running the same driver over a growing target list is cheap and safe, a crashed target resumes from the first missing product, and recomputation is an explicit, single-field opt-in.

## The model

Two orthogonal axes, cleanly separated:

- **In scope?** — the existing step booleans (`extract_cubes=True`, …). Unchanged.
- **Redo or skip?** — one new field, `PipelineStepsConfig.force: bool | set[str]`, replacing all four `overwrite_*` flags:

```python
config.steps.force = False                 # DEFAULT: resume — skip enabled steps whose outputs exist
config.steps.force = True                   # redo every enabled step
config.steps.force = {"extract_cubes"}      # redo extract_cubes AND every step after it (cascade)
```

`force` with a set **cascades**: forcing a step also forces everything downstream, because those steps consume its products (re-extracting while letting the bundle/centres/TRAP skip would leave them on stale inputs).

## Behaviour at the defaults

| Scenario | Result |
|---|---|
| New target added; others already done | New target runs fully; finished targets skip every step |
| Target crashed mid-way; re-run | Completed steps skip; resumes at the first missing product |
| Redo a step after a code/version change | `force={"that_step"}` — cascades downstream |
| Full clean re-reduction | `force=True` |

## Key changes

- **`step_registry.py` (new)** — single source of truth mapping each step to its canonical log name, expected output files, pipeline order, `is_final`/`internal_guard`/`is_trap` flags, and completion markers. `should_run()` and `check_output()` both derive from it. Stdlib-only (keeps the database half importable without the pipeline extra).
- **`ifs_reduction.py`** — each `if steps.X:` becomes `if should_run("X", …):`; the skip decision moves out of individual steps into the orchestrator. Per-step `overwrite` parameters removed from the 5 IFS step modules.
- **Two internal-guard steps** kept their own skip logic but are now driven by the same `force`: `reduce_calibration` (writes a cross-target shared wavecal dir) and `run_trap_reduction` (skip lives in the trap repo) — via `_forced(...)`, so the cascade reaches them.
- **Completion markers** for the two steps whose real outputs can't be trusted: `extract_cubes` tolerates partial DIT failures (file presence ≠ complete), and TRAP detection's outputs live in the trap repo — each writes a parent-side `.<step>.done` marker only on success.
- **`reduction_status`** now treats the new `skipped_complete` log status as healthy/complete, so a resumed target isn't misreported as incomplete (the per-run jsonlog is archived each run, so the aggregator only sees the latest run).
- **`check_output()`** rederived from the registry — also fixes a latent bug where it looked for `additional_outputs/` at `…/{method}/additional_outputs` while the step modules write it at `…/{method}/converted/additional_outputs`.

## Breaking changes

- Removed `PipelineStepsConfig.overwrite_calibration/overwrite_bundle/overwrite_preprocessing/overwrite_trap`. Drivers setting them must switch to `force`. The shipped template never set them, so its **behaviour changes**: re-runs now resume instead of recompute (the intended improvement — see CHANGELOG).
- `trap_config.processing.overwrite_reduction` is no longer set by hand in IFS drivers; it's driven by `force`.

## Testing

- New unit tests: `tests/test_resume_skip.py` (registry, `should_run` gate, cascade, `force` validation, marker roundtrip, registry-driven `check_output`) and `tests/test_reduction_status_resume.py` (aggregator: `skipped_complete` → complete; plain `skipped`/`failed` → not).
- Offline suite green: 50 passed across `test_resume_skip`, `test_reduction_status_resume`, `test_config`, `test_imports_fixed`, `test_logging`.
- Per repo policy the end-to-end heavy resume run (real data) is **not** in CI — recommend a maintainer smoke test (marker written → second run skips to `spot_to_flux` → `reduction_status` shows `skipped_complete`/complete) before relying on it in production.

## Notes

- Deferred polish (non-blocking): a partial-multi-output `should_run` test, an em dash in one log string, an untyped `logger` param, and some quoted type annotations.
- Design/spec docs and `llm_docs/` are intentionally not committed.
